### PR TITLE
[Request] proper code indentation in comments

### DIFF
--- a/app/Vimrcfu/Core/Text.php
+++ b/app/Vimrcfu/Core/Text.php
@@ -1,6 +1,6 @@
 <?php namespace Vimrcfu\Core;
 
-use Michelf\Markdown;
+use Michelf\MarkdownExtra;
 
 class Text {
 
@@ -56,7 +56,7 @@ class Text {
    */
   private function renderMarkdown($text)
   {
-    return Markdown::defaultTransform($text);
+    return MarkdownExtra::defaultTransform($text);
   }
 
   /**

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -73,8 +73,18 @@ textarea.snippet
   font-size: 0.9em;
 }
 
+/* block code */
 .comment-box code
 {
+  display: block;
+  white-space: pre;
+  overflow: auto;
+}
+
+/* inline code */
+.comment-box p code
+{
+  display: inline;
   white-space: pre-line;
 }
 


### PR DESCRIPTION
The code blocks indentation is not respected in comments (ex: http://vimrcfu.com/snippet/112)

Also, we can't add blank lines in code blocks without breaking all the style.